### PR TITLE
feat: Add Work Experience section

### DIFF
--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useEffect, useRef } from 'react';
+import type { WorkExperience } from '../types/experience';
+
+interface ExperienceCardProps {
+  experience: WorkExperience;
+  delay?: number;
+}
+
+const ExperienceCard: React.FC<ExperienceCardProps> = ({ experience, delay = 0 }) => {
+  const [visible, setVisible] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          // Apply delay if provided, otherwise set visible immediately
+          if (delay > 0) {
+            setTimeout(() => setVisible(true), delay);
+          } else {
+            setVisible(true);
+          }
+        }
+      },
+      { threshold: 0.1 } // Trigger when 10% of the card is visible
+    );
+
+    const currentCardRef = cardRef.current; // Capture value for cleanup
+
+    if (currentCardRef) {
+      observer.observe(currentCardRef);
+    }
+
+    return () => {
+      if (currentCardRef) {
+        observer.unobserve(currentCardRef);
+      }
+    };
+  }, [delay]);
+
+  return (
+    <div
+      ref={cardRef}
+      className={`group rounded-lg overflow-hidden glass transition-all duration-500 ease-out opacity-0 ${
+        visible ? 'animate-zoom-in opacity-100' : ''
+      } hover:shadow-2xl border border-white/10`} // Added border, adjusted shadow and opacity transition
+    >
+      {experience.logoUrl && (
+        <div className="h-40 flex items-center justify-center bg-slate-800/30 p-4"> {/* Adjusted bg color */}
+          <img
+            src={experience.logoUrl}
+            alt={`${experience.company} logo`}
+            className="max-h-full max-w-[150px] object-contain rounded-md" // Adjusted max-width
+          />
+        </div>
+      )}
+      <div className="p-6">
+        <h3 className="text-xl font-semibold mb-1 text-white">{experience.company}</h3> {/* Adjusted text color */}
+        <p className="text-customOrange font-medium mb-1">{experience.title}</p> {/* Adjusted text color */}
+        <p className="text-xs text-slate-400 mb-4"> {/* Adjusted text color and margin */}
+          {experience.startDate} – {experience.endDate}
+        </p>
+
+        {experience.responsibilities && experience.responsibilities.length > 0 && (
+          <div className="mb-4">
+            <h4 className="text-sm font-semibold text-slate-200 mb-2">Key Responsibilities:</h4> {/* Adjusted text color and margin */}
+            <ul className="list-disc list-inside space-y-1 text-slate-300 text-sm"> {/* Adjusted text color */}
+              {experience.responsibilities.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {experience.technologies && experience.technologies.length > 0 && (
+          <div>
+            <h4 className="text-sm font-semibold text-slate-200 mb-2">Technologies Used:</h4> {/* Adjusted text color */}
+            <div className="flex flex-wrap gap-2">
+              {experience.technologies.map((tech, index) => (
+                <span
+                  key={index}
+                  className="px-3 py-1 text-xs rounded-full bg-customOrange/10 text-customOrange border border-customOrange/30" // Adjusted colors and padding
+                >
+                  {tech}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ExperienceCard;

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -1,0 +1,24 @@
+import { WorkExperience } from '../types/experience';
+
+export const experiences: WorkExperience[] = [
+  {
+    company: "Multi Canal Services",
+    title: "Full Stack Developer",
+    startDate: "YYYY-MM-DD", // Placeholder
+    endDate: "Present", // Placeholder
+    responsibilities: [
+      "Developed and maintained web applications.",
+      "Collaborated with team members on various projects.",
+      "Participated in code reviews and sprint planning.",
+    ],
+    technologies: [
+      "React",
+      "Node.js",
+      "TypeScript",
+      "Express.js",
+      "MongoDB"
+    ],
+    logoUrl: "https://multicanalservices.com/wp-content/uploads/2018/10/logo.png"
+  },
+  // Add more experiences here if needed
+];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import HeroSection from '../sections/HeroSection';
 import AboutSection from '../sections/AboutSection';
 import ProjectsSection from '../sections/ProjectsSection';
 import EducationSection from '../sections/EducationSection';
+import ExperienceSection from '../sections/ExperienceSection'; // Added import
 import ContactSection from '../sections/ContactSection';
 import CustomCursor from '../components/CustomCursor';
 import FormationSection from '../sections/FormationSection';
@@ -41,6 +42,7 @@ const Index: React.FC = () => {
         <FormationSection />
         <ProjectsSection />
         <EducationSection />
+        <ExperienceSection /> {/* Added section */}
         <WorkJournalSection /> {/* Newly added section */}
         <ContactSection />
       </main>

--- a/src/sections/ExperienceSection.tsx
+++ b/src/sections/ExperienceSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { experiences } from '../data/experiences';
+import ExperienceCard from '../components/ExperienceCard';
+// Assuming section-title provides necessary base styling (like font size, weight, color)
+// Adding text-center and margin-bottom here for layout control.
+
+const ExperienceSection: React.FC = () => {
+  return (
+    <section id="experience" className="py-20">
+      <div className="container mx-auto px-4"> {/* Added mx-auto and px-4 for typical container behavior */}
+        <h2 className="text-3xl font-bold text-center mb-12 text-white"> {/* Assuming section-title might not exist, providing defaults */}
+          Expérience Professionnelle
+        </h2>
+
+        {experiences && experiences.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {experiences.map((exp, index) => (
+              <ExperienceCard
+                key={`${exp.company}-${exp.title}-${index}`} // Enhanced key
+                experience={exp}
+                delay={index * 200}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 text-slate-400"> {/* Adjusted text color for muted message */}
+            <p>Aucune expérience professionnelle à afficher pour le moment.</p>
+            <p className="mt-2 text-sm">Veuillez ajouter des données dans <code>src/data/experiences.ts</code>.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default ExperienceSection;

--- a/src/types/experience.ts
+++ b/src/types/experience.ts
@@ -1,0 +1,9 @@
+export interface WorkExperience {
+  company: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  responsibilities: string[];
+  technologies: string[];
+  logoUrl?: string;
+}


### PR DESCRIPTION
This commit introduces a new "Work Experience" section to the portfolio.

Key changes include:
- Definition of a `WorkExperience` type in `src/types/experience.ts`.
- Creation of `src/data/experiences.ts` with placeholder data for Multi Canal Services.
- A new `ExperienceCard.tsx` component in `src/components/` to display individual work experiences, featuring company logo, title, dates, responsibilities, and technologies used. This card is styled to match the existing project aesthetic, including a glass effect and zoom-in animation.
- A new `ExperienceSection.tsx` component in `src/sections/` that arranges multiple `ExperienceCard` components in a responsive grid.
- Integration of the `ExperienceSection` into the main page (`src/pages/Index.tsx`) after the "Education" section.

The new components utilize existing Tailwind CSS theme variables and styles, ensuring visual consistency with the rest of the application.